### PR TITLE
Fix: Clean text logging format without weird characters

### DIFF
--- a/src/datamap_cli/cli.py
+++ b/src/datamap_cli/cli.py
@@ -260,9 +260,13 @@ def main(
     # Set up logging
     log_level = get_effective_log_level()
     
+    # Use CLI context to resolve color_output
+    from .utils.cli_context import resolve_color_output
+    resolved_color_output = resolve_color_output(color_output)
+    
     setup_logging(
         log_level=log_level,
-        color_output=color_output if color_output is not None else True
+        color_output=resolved_color_output
     )
     
 

--- a/src/datamap_cli/utils/cli_context.py
+++ b/src/datamap_cli/utils/cli_context.py
@@ -130,7 +130,7 @@ def should_show_progress() -> bool:
 
 
 def get_effective_log_level() -> str:
-    """Get effective log level based on global options.
+    """Get effective log level based on global options and configuration.
     
     Returns:
         Effective log level
@@ -140,4 +140,6 @@ def get_effective_log_level() -> str:
     elif get_global_quiet():
         return "ERROR"
     else:
-        return "INFO" 
+        # Use configuration file log level as default
+        from ..config.settings import get_settings
+        return get_settings().log_level 


### PR DESCRIPTION
## Issue Fixed

The log_format: text was printing weird ANSI color codes when color_output: false was set in the configuration file.

### Root Cause
1. CLI was defaulting to color_output=True regardless of configuration file settings
2. Even with color_output=False, structlog was still using Rich's ConsoleRenderer
3. No proper plain text renderer for structlog without color codes

### Solution
1. Created custom plain_text_renderer() function for clean text output
2. Fixed CLI to use resolve_color_output() instead of hardcoded True default
3. Updated logging setup to properly handle text format without colors

### Testing
Before: [07/27/25 19:15:26] INFO [2m2025-07-27T22:15:26.611648Z[0m [[32m[1minfo[0m]
After: [2025-07-27 22:18:26] INFO [datamap_cli.cli] Command started

### Impact
- Clean, readable logs for scripting and automation
- Properly respects configuration file settings
- No more weird characters in log output
- Maintains colored output when explicitly requested